### PR TITLE
Add configuration module

### DIFF
--- a/Complete_Model_HPC_callrate_v5_45_24.py
+++ b/Complete_Model_HPC_callrate_v5_45_24.py
@@ -123,15 +123,14 @@ callrate 5.46.24: the callrate works on batch 1, cell count 100 on hpc. performa
 '''
 script_start_time = time.time()
 
-#pre-parameters. IMPORTANT! this determines what cells will be considered and what edge index will be used. 
-num_excitatory_cells = 1000 #len(graph_idx_list) #number of excitatory cells to use.
-hpc_run = True #sets the working directory for hpc or local.
-if hpc_run == True:
-    os.chdir(r"/rds/general/user/rhc222/home/Thesis/") #use this for hpc
-else:
-    os.chdir(r"C:\Users\username\OneDrive - Imperial College London\0_Imperial_main_asof_1.19.23\0Thesis_Project\0MAIN")
-synth_data = False #if true, will use synthetic data. if false, will use real data.
-synth_data_stamp_name = "20230810_140641"
+#pre-parameters are now loaded from config.py so paths are not hard coded
+from config import CONFIG
+
+num_excitatory_cells = CONFIG.num_excitatory_cells
+hpc_run = CONFIG.hpc_run
+os.chdir(CONFIG.base_path)
+synth_data = CONFIG.synth_data
+synth_data_stamp_name = CONFIG.synth_data_stamp_name
 if synth_data == True:
     with open(f"synth_datasets/dataset_{synth_data_stamp_name}/dataset_{synth_data_stamp_name}_graph_idx_list.pkl", 'rb') as f:
         synth_graph_idx_list = pickle.load(f)
@@ -159,7 +158,7 @@ else:
 
 num_graphs = len(graph_idx_list)
 split_point_for_traintest = int(len(graph_idx_list)*.8) #cell count used for training, rest for testing. 
-num_epochs = 30
+num_epochs = CONFIG.num_epochs
 batch_size =  1 
 pooling_keep_count = int(187215) #the number of nodes kept in pooling. 187215 is the node count, menaing none are dropped. 
 learning_rate = .001 

--- a/Synth_Model_v3_37_22.py
+++ b/Synth_Model_v3_37_22.py
@@ -113,15 +113,14 @@ model_notes = '''
 '''
 script_start_time = time.time()
 
-#pre-parameters. IMPORTANT! this determines what cells will be considered and what edge index will be used. 
-num_excitatory_cells = 10 #len(graph_idx_list) #number of excitatory cells to use.
-hpc_run = False #sets the working directory for hpc or local.
-if hpc_run == True:
-    os.chdir(r"/rds/general/user/rhc222/home/Thesis/") #use this for hpc
-else:
-    os.chdir(r"C:\Users\username\OneDrive - Imperial College London\0_Imperial_main_asof_1.19.23\0Thesis_Project\0MAIN")
-synth_data = True #if true, will use synthetic data. if false, will use real data.
-synth_data_stamp_name = "20230809_175500"
+#pre-parameters are now loaded from config.py
+from config import CONFIG
+
+num_excitatory_cells = CONFIG.num_excitatory_cells
+hpc_run = CONFIG.hpc_run
+os.chdir(CONFIG.base_path)
+synth_data = CONFIG.synth_data
+synth_data_stamp_name = CONFIG.synth_data_stamp_name
 if synth_data == True:
     with open(f"synth_datasets/dataset_{synth_data_stamp_name}/dataset_{synth_data_stamp_name}_graph_idx_list.pkl", 'rb') as f:
         synth_graph_idx_list = pickle.load(f)
@@ -149,7 +148,7 @@ else:
 
 num_graphs = len(graph_idx_list)
 split_point_for_traintest = int(len(graph_idx_list)*.8) #cell count used for training, rest for testing. 
-num_epochs = 10
+num_epochs = CONFIG.num_epochs
 batch_size =  100 
 pooling_keep_count = int(187215) #the number of nodes kept in pooling. 187215 is the node count, menaing none are dropped. 
 learning_rate = .01 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+@dataclass
+class Config:
+    base_path: str
+    hpc_run: bool
+    synth_data: bool
+    synth_data_stamp_name: str
+    num_excitatory_cells: int
+    num_epochs: int
+
+# Sample configuration for running on an HPC cluster
+HPC_CONFIG = Config(
+    base_path="/rds/general/user/rhc222/home/Thesis/",
+    hpc_run=True,
+    synth_data=False,
+    synth_data_stamp_name="20230810_140641",
+    num_excitatory_cells=1000,
+    num_epochs=30,
+)
+
+# Sample configuration for running locally
+LOCAL_CONFIG = Config(
+    base_path=r"C:\\Users\\username\\OneDrive - Imperial College London\\0_Imperial_main_asof_1.19.23\\0Thesis_Project\\0MAIN",
+    hpc_run=False,
+    synth_data=True,
+    synth_data_stamp_name="20230809_175500",
+    num_excitatory_cells=10,
+    num_epochs=10,
+)
+
+# Select which configuration to use
+CONFIG = HPC_CONFIG

--- a/src/train.py
+++ b/src/train.py
@@ -4,6 +4,9 @@ import pandas as pd
 import torch
 import torchmetrics
 import matplotlib.pyplot as plt
+from config import CONFIG
+
+num_epochs = CONFIG.num_epochs
 
 
 def train():


### PR DESCRIPTION
## Summary
- externalize runtime parameters to `config.py`
- load `CONFIG` in main scripts and training module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6851946fcfc483249947ba2f42a957ca