### PR TITLE
Clean up training scripts

### DIFF
--- a/Complete_Model_HPC_callrate_v5_45_24.py
+++ b/Complete_Model_HPC_callrate_v5_45_24.py
@@ -1,9 +1,7 @@
 #full model set for hpc (includes attempts to send to gpu)
 print('importing packages')
-import subprocess
-import sys
-def install_package(package): #install packages with this tool | Example usage: install_package("torchmetrics")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+# Install dependencies before running:
+#   pip install -r requirements.txt
 import os
 import os.path as osp
 import torch

--- a/Synth_Model_v3_37_22.py
+++ b/Synth_Model_v3_37_22.py
@@ -1,9 +1,7 @@
 #full model set for hpc (includes attempts to send to gpu)
 print('importing packages')
-import subprocess
-import sys
-def install_package(package): #install packages with this tool | Example usage: install_package("torchmetrics")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+# Install dependencies before running:
+#   pip install -r requirements.txt
 import os
 import os.path as osp
 import torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Required Python packages
 matplotlib
 pandas
 torch


### PR DESCRIPTION
## Summary
- remove unused install_package helper from training scripts
- document Python dependencies in requirements.txt
- prompt users in training scripts to install dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851cf588e7c8324877b397f86791a83