### PR TITLE
Select config via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ python -m pip install -r requirements.txt
 python Complete_Model_HPC_callrate_v5_45_24.py
 ```
 
+### Configuration Selection
+
+The file `config.py` contains example settings for running either locally or on
+an HPC cluster. By default the local configuration is used. Set the environment
+variable `GAT_CONFIG` to `HPC` before executing a script to switch to the HPC
+configuration:
+
+```bash
+export GAT_CONFIG=HPC
+python Complete_Model_HPC_callrate_v5_45_24.py
+```
+
 Synthetic data experiments can be executed with `Synth_Model_v3_37_22.py`.
 
 ## Testing

--- a/config.py
+++ b/config.py
@@ -29,5 +29,11 @@ LOCAL_CONFIG = Config(
     num_epochs=10,
 )
 
-# Select which configuration to use
-CONFIG = HPC_CONFIG
+# Select which configuration to use based on environment variable
+import os
+
+# Set the environment variable ``GAT_CONFIG`` to ``"HPC"`` to use ``HPC_CONFIG``.
+# Any other value (or if the variable is unset) will fall back to ``LOCAL_CONFIG``.
+use_hpc = os.getenv("GAT_CONFIG", "LOCAL").upper() == "HPC"
+
+CONFIG = HPC_CONFIG if use_hpc else LOCAL_CONFIG


### PR DESCRIPTION
## Summary
- set `CONFIG` based on `GAT_CONFIG` env variable
- document configuration selection in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851d383a6c08324a1b3bab3d1fcf067