### PR TITLE
Wrap training in main

### DIFF
--- a/Complete_Model_HPC_callrate_v5_45_24.py
+++ b/Complete_Model_HPC_callrate_v5_45_24.py
@@ -310,4 +310,9 @@ criterion = torch.nn.CrossEntropyLoss()
 print('model defined')
 
 
-run_training()
+def main():
+    run_training()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- wrap training launch in `Complete_Model_HPC_callrate_v5_45_24.py`
- wrap training loop of `Synth_Model_v3_37_22.py` in a new main

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6851d7ac75288324ad800d185ba36d57